### PR TITLE
Silence rollup replace warning

### DIFF
--- a/packages/plaid-rollup/rollup/index.js
+++ b/packages/plaid-rollup/rollup/index.js
@@ -46,6 +46,7 @@ const rollupPlugins = {
       ...values,
       ...replaceValues,
     },
+    preventAssignment: true,
   }),
   resolve: options => resolve(options),
   commonjs: options => commonjs(options),


### PR DESCRIPTION
(!) Plugin replace: @rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to `true`, as the next major version will default this option to `true`.

(was trying this in a Violentmonkey user script builder)